### PR TITLE
Implement update and remove methods for MockDatabaseReference

### DIFF
--- a/lib/src/mock_database_reference.dart
+++ b/lib/src/mock_database_reference.dart
@@ -122,6 +122,28 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     }
   }
 
+  @override
+  Future<void> update(Map<String, Object?> value) async {
+    value = _parseValue(value);
+    Map<String, dynamic> _baseData = _getDataHandle(_nodePath, _data, true)!;
+
+    if (key != null && _baseData[key] == null) {
+      _baseData[key!] = <String, dynamic>{};
+    }
+
+    if (key != null) {
+      _baseData = _baseData[key]!;
+    }
+
+    for(var _key in value.keys){
+      final segments = _key.split('/');
+      final innerKey = segments.isNotEmpty ? segments.last : _key;
+      final _data = _getDataHandle(_key, _baseData, true)!;
+
+      _data[innerKey] = value[_key];
+    }
+  }
+
   /// Recursively converts Maps into Map<String, dynamic>, so it is possible to change type later.
   dynamic _parseValue(dynamic value) {
     if (value is Map) {
@@ -134,11 +156,19 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     return value;
   }
 
+  String _removeSlashes(String path) {
+    if(path.startsWith('/')){
+      path = path.substring(1);
+    }
+    if(path.endsWith('/')){
+      path = path.substring(0, path.length - 1);
+    }
+    return path;
+  }
+
   Map<String, dynamic>? _getDataHandle(String path, Map<String, dynamic>? data,
       [bool createIfMissing = false]) {
-    if (path.length > 1) {
-      path = path.substring(1, path.length - 1);
-    }
+    path = _removeSlashes(path);
     final pathSegments = path.split('/');
     if (pathSegments.length == 1) {
       return data;
@@ -240,6 +270,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     return Future.value(MockDataSnapshot(this, tempData));
   }
 
+  @override
   Future<void> remove() => set(null);
 }
 

--- a/lib/src/mock_database_reference.dart
+++ b/lib/src/mock_database_reference.dart
@@ -43,7 +43,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     if (_nodePath == '/') {
       return null;
     }
-    return _nodePath.substring(1, _nodePath.length - 1).split('/').last;
+    return _trimSlashes(_nodePath).split('/').last;
   }
 
   @override
@@ -83,43 +83,6 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     } else {
       data![key!] = value;
     }
-
-    return;
-
-    if (_nodePath == '/') {
-      _data = value;
-    } else {
-      var nodePathWithoutSlashesAtEndAndStart =
-          _nodePath.substring(1, _nodePath.length - 1);
-      var nodesList = nodePathWithoutSlashesAtEndAndStart.split('/');
-      Map<String, dynamic>? tempData = <String, dynamic>{};
-      Map<String, dynamic>? lastNodeInCurrentData;
-      var nodeIndexReference = _Int(0);
-      if (_data![nodesList.first] == null) {
-        lastNodeInCurrentData = _data;
-      } else {
-        lastNodeInCurrentData = _getNextNodeData(
-            data: _data, nodesList: nodesList, nodeIndex: nodeIndexReference);
-      }
-      var nodeIndex = nodeIndexReference.value;
-      var noNewNodeToAdd = nodesList.length <= nodeIndex;
-      if (noNewNodeToAdd) {
-        lastNodeInCurrentData![nodesList.last] = value;
-      } else {
-        var firstNodeInNewData = nodesList[nodeIndex++];
-        if (nodeIndex < nodesList.length) {
-          tempData = _buildNewNodesTree(
-            nodeIndex: nodeIndex,
-            nodesList: nodesList,
-            data: tempData,
-            value: value,
-          );
-          lastNodeInCurrentData!.addAll({firstNodeInNewData: tempData});
-        } else {
-          lastNodeInCurrentData!.addAll({firstNodeInNewData: value});
-        }
-      }
-    }
   }
 
   @override
@@ -156,7 +119,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     return value;
   }
 
-  String _removeSlashes(String path) {
+  String _trimSlashes(String path) {
     if(path.startsWith('/')){
       path = path.substring(1);
     }
@@ -168,7 +131,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
 
   Map<String, dynamic>? _getDataHandle(String path, Map<String, dynamic>? data,
       [bool createIfMissing = false]) {
-    path = _removeSlashes(path);
+    path = _trimSlashes(path);
     final pathSegments = path.split('/');
     if (pathSegments.length == 1) {
       return data;
@@ -195,49 +158,13 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     return _data;
   }
 
-  Map<String, dynamic>? _buildNewNodesTree({
-    required dynamic data,
-    required List<String> nodesList,
-    required int nodeIndex,
-    required value,
-  }) {
-    var nextNodeIndex = nodeIndex + 1;
-    if (nodeIndex + 1 < nodesList.length) {
-      data[nodesList[nodeIndex]] = {nodesList[nextNodeIndex]: Object()};
-      _buildNewNodesTree(
-          data: data[nodesList[nodeIndex]],
-          nodesList: nodesList,
-          nodeIndex: nextNodeIndex,
-          value: value);
-    } else
-      data[nodesList[nodeIndex]] = value;
-    return data;
-  }
-
-  _getNextNodeData({
-    required dynamic data,
-    required List<String> nodesList,
-    required _Int nodeIndex,
-  }) {
-    if (nodesList.length <= nodeIndex.value ||
-        !(data[nodesList[nodeIndex.value]] is Map)) {
-      nodeIndex.increment();
-      return data;
-    }
-    return _getNextNodeData(
-      data: data[nodesList[nodeIndex.value]],
-      nodesList: nodesList,
-      nodeIndex: nodeIndex.increment(),
-    );
-  }
-
   dynamic _getCurrentData() {
     if (_nodePath == '/') {
       return _data;
     }
     var tempData = _data;
     // remove start and end slashes.
-    var nodePath = _nodePath.substring(1, _nodePath.length - 1);
+    var nodePath = _trimSlashes(_nodePath);
     var nodeList = nodePath.split('/');
     if (nodeList.length > 1) {
       for (var i = 0; i < nodeList.length; i++) {

--- a/lib/src/mock_database_reference.dart
+++ b/lib/src/mock_database_reference.dart
@@ -98,7 +98,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
       _baseData = _baseData[key]!;
     }
 
-    for(var _key in value.keys){
+    for (var _key in value.keys) {
       final segments = _key.split('/');
       final innerKey = segments.isNotEmpty ? segments.last : _key;
       final _data = _getDataHandle(_key, _baseData, true)!;
@@ -120,10 +120,10 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
   }
 
   String _trimSlashes(String path) {
-    if(path.startsWith('/')){
+    if (path.startsWith('/')) {
       path = path.substring(1);
     }
-    if(path.endsWith('/')){
+    if (path.endsWith('/')) {
       path = path.substring(0, path.length - 1);
     }
     return path;

--- a/lib/src/mock_database_reference.dart
+++ b/lib/src/mock_database_reference.dart
@@ -11,9 +11,9 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
 
   // ignore: prefer_final_fields
   static Map<String, dynamic>? _persistedData = <String, dynamic>{};
-  Map<String, dynamic>? _volatileData = <String, dynamic>{};
+  Map<String, dynamic>? _volatileData;
 
-  MockDatabaseReference();
+  MockDatabaseReference([this._volatileData]);
 
   MockDatabaseReference._(nodePath, [this._volatileData]) {
     _nodePath += nodePath;

--- a/lib/src/mock_database_reference.dart
+++ b/lib/src/mock_database_reference.dart
@@ -107,18 +107,22 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     }
   }
 
-  /// Recursively converts Maps into Map<String, dynamic>, so it is possible to change type later.
+  /// Recursively converts Maps into Map<String, dynamic>,
+  /// so it is possible to change type later.
   dynamic _parseValue(dynamic value) {
     if (value is Map) {
       // todo: check if keys contain forbidden characters: '/', '.', '#', '$', '[', or ']'
       // additionally, in case of update '/' should be allowed
-      return Map.fromEntries(value.entries
-          .map((e) => MapEntry(e.key.toString(), _parseValue(e.value))));
+      return Map.fromEntries(
+        value.entries
+            .map((e) => MapEntry(e.key.toString(), _parseValue(e.value))),
+      );
     }
 
     return value;
   }
 
+  /// Removes slashes from start and end of given path.
   String _trimSlashes(String path) {
     if (path.startsWith('/')) {
       path = path.substring(1);
@@ -129,14 +133,24 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     return path;
   }
 
-  Map<String, dynamic>? _getDataHandle(String path, Map<String, dynamic>? data,
-      [bool createIfMissing = false]) {
+  /// Gets the map containing value for given path,
+  /// e.g. given the path foo/bar/baz it returns the map at foo/bar,
+  /// which you can then use to access value at baz.
+  /// If createIfMissing is set to true and nested map will not be found,
+  /// it will be created, so null won't be returned.
+  Map<String, dynamic>? _getDataHandle(
+    String path,
+    Map<String, dynamic>? data, [
+    bool createIfMissing = false,
+  ]) {
     path = _trimSlashes(path);
     final pathSegments = path.split('/');
     if (pathSegments.length == 1) {
+      // nothing to traverse
       return data;
     }
 
+    // The caller will access the value at key.
     final segmentsWithoutKey = pathSegments.take(pathSegments.length - 1);
     Map<String, dynamic>? _data = data;
     for (var segment in segmentsWithoutKey) {
@@ -199,17 +213,6 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
 
   @override
   Future<void> remove() => set(null);
-}
-
-class _Int {
-  int value;
-
-  _Int(this.value);
-
-  _Int increment() {
-    ++value;
-    return this;
-  }
 }
 
 // Map<String, dynamic> _makeSupportGenericValue(Map<String, dynamic> data) {

--- a/lib/src/mock_firebase_database.dart
+++ b/lib/src/mock_firebase_database.dart
@@ -5,6 +5,7 @@ import 'mock_database_reference.dart';
 
 class MockFirebaseDatabase extends Mock implements FirebaseDatabase {
   static FirebaseDatabase get instance => MockFirebaseDatabase();
+
   static get persistData => _persistData;
 
   Map<String, dynamic> _volatileData = <String, dynamic>{};
@@ -22,6 +23,7 @@ class MockFirebaseDatabase extends Mock implements FirebaseDatabase {
 
   // ignore: unused_field
   static bool _persistData = true;
+
   //Todo support non persistence.
   static void setDataPersistenceEnabled({bool enabled = true}) {
     _persistData = enabled;

--- a/lib/src/mock_firebase_database.dart
+++ b/lib/src/mock_firebase_database.dart
@@ -6,15 +6,18 @@ import 'mock_database_reference.dart';
 class MockFirebaseDatabase extends Mock implements FirebaseDatabase {
   static FirebaseDatabase get instance => MockFirebaseDatabase();
   static get persistData => _persistData;
+
+  Map<String, dynamic> _volatileData = <String, dynamic>{};
+
   @override
   DatabaseReference reference() => ref();
 
   @override
   DatabaseReference ref([String? path]) {
     if (path != null) {
-      return MockDatabaseReference().child(path);
+      return MockDatabaseReference(_volatileData).child(path);
     }
-    return MockDatabaseReference();
+    return MockDatabaseReference(_volatileData);
   }
 
   // ignore: unused_field

--- a/test/mock_database_reference_test.dart
+++ b/test/mock_database_reference_test.dart
@@ -4,10 +4,10 @@ import 'package:firebase_database_mocks/src/mock_database_reference.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  late MockDatabaseReference databaseReference;
+  late DatabaseReference databaseReference;
   setUp(() {
     setupFirebaseMocks(); // Just to make sure it that no exception is thrown.
-    databaseReference = MockDatabaseReference();
+    databaseReference = MockFirebaseDatabase.instance.ref();
   });
 
   group('Node path handling : ', () {
@@ -35,7 +35,7 @@ void main() {
         equals(MockDatabaseReference().child('test').path),
       );
     });
-    test('Should work with slash as suffix', () {
+    test('Should work with slash as prefix and suffix', () {
       expect(
         databaseReference.child('/test/').path,
         equals(MockDatabaseReference().child('test').path),
@@ -258,7 +258,7 @@ void main() {
         equals('otherValue'),
       );
       expect(
-          (await MockDatabaseReference().child('test_').once()).snapshot.value,
+          (await MockFirebaseDatabase().ref().child('test_').once()).snapshot.value,
           isNull);
     });
   });

--- a/test/mock_database_reference_test.dart
+++ b/test/mock_database_reference_test.dart
@@ -283,6 +283,98 @@ void main() {
     });
   });
 
+  group('update', () {
+    late DatabaseReference reference;
+
+    setUp(() async {
+      reference = databaseReference.child('update');
+      await reference.set({
+        'shallow': 'data',
+        'nested': {
+          'foo': {
+            'bar': 'baz',
+          },
+        },
+      });
+    });
+
+    test('should update shallow data', () async {
+      await reference.update({'shallow': 'foo'});
+      final snapshot = await reference.get();
+      expect(
+        snapshot.value,
+        equals({
+          'shallow': 'foo',
+          'nested': {
+            'foo': {
+              'bar': 'baz',
+            },
+          },
+        }),
+      );
+    });
+
+    test('should update nested data', () async {
+      await reference.update({
+        'nested': {
+          'foo': {'bar': 'foo'}
+        }
+      });
+      final snapshot = await reference.get();
+      expect(
+        snapshot.value,
+        equals({
+          'shallow': 'data',
+          'nested': {
+            'foo': {
+              'bar': 'foo',
+            },
+          },
+        }),
+      );
+    });
+
+    test('should update many locations simultaneously', () async {
+      await reference.update({
+        'shallow': 'foo',
+        'nested': {
+          'foo': {'bar': 'foo'}
+        }
+      });
+      final snapshot = await reference.get();
+      expect(
+        snapshot.value,
+        equals({
+          'shallow': 'foo',
+          'nested': {
+            'foo': {
+              'bar': 'foo',
+            },
+          },
+        }),
+      );
+    });
+
+    test('should work with slash separated keys', () async {
+      await reference.update({
+        'shallow': 'foo',
+        'nested/foo/bar': 'foo',
+      });
+      final snapshot = await reference.get();
+      expect(
+        snapshot.value,
+        equals({
+          'shallow': 'foo',
+          'nested': {
+            'foo': {
+              'bar': 'foo',
+            },
+          },
+        }),
+      );
+    });
+  });
+
   group('push', () {
     late DatabaseReference reference;
 

--- a/test/mock_database_reference_test.dart
+++ b/test/mock_database_reference_test.dart
@@ -144,7 +144,7 @@ void main() {
     });
 
     test('Should set data in nested nodes', () async {
-      databaseReference
+      await databaseReference
           .child('path_')
           .child('mock_')
           .child('test_')
@@ -222,7 +222,7 @@ void main() {
       MockDatabaseReference? _databaseReference = MockDatabaseReference();
       await _databaseReference.child('test1').set('value1');
       await _databaseReference.child('test2/test2').set('value2');
-      await _databaseReference.child('test1/test_one').set('value3');
+      await _databaseReference.child('test3/test_one').set('value3');
       _databaseReference = null;
       expect(_databaseReference, isNull);
 
@@ -237,7 +237,7 @@ void main() {
         equals('value2'),
       );
       expect(
-        (await newDatabaseReference.child('test1/test_one').once())
+        (await newDatabaseReference.child('test3/test_one').once())
             .snapshot
             .value,
         equals('value3'),
@@ -258,7 +258,9 @@ void main() {
         equals('otherValue'),
       );
       expect(
-          (await MockFirebaseDatabase().ref().child('test_').once()).snapshot.value,
+          (await MockFirebaseDatabase().ref().child('test_').once())
+              .snapshot
+              .value,
           isNull);
     });
   });
@@ -307,6 +309,46 @@ void main() {
 
       expect(reference1.key!.compareTo(reference2.key!), lessThan(0));
     });
+  });
+
+  group('remove', () {
+    late DatabaseReference reference;
+    late DatabaseReference shallowReference;
+    late DatabaseReference nestedReference;
+
+    setUp(() async {
+      reference = databaseReference.child('remove');
+      await reference.set({
+        'shallow': 'data',
+        'nested': {
+          'foo': {
+            'bar': 'baz',
+          },
+        },
+      });
+      shallowReference = reference.child('shallow');
+      nestedReference = reference.child('nested');
+    });
+
+    test('should remove shallow data', () async {
+      await shallowReference.remove();
+      final snapshot = await shallowReference.get();
+      expect(snapshot.exists, isFalse);
+    });
+
+    test('should remove nested data', () async {
+      await nestedReference.remove();
+      final snapshot = await nestedReference.get();
+      expect(snapshot.exists, isFalse);
+    });
+
+    // todo: uncomment when fixed
+    // test('should remove whole map if its only key is removed', () async {
+    //   await nestedReference.child('foo/bar').remove();
+    //   final snapshot = await nestedReference.get();
+    //   print(snapshot.value);
+    //   expect(snapshot.exists, isFalse);
+    // });
   });
 
   // Todo implement all dataSnapshot, dbReference and fbDatabase getters and setters if possible.

--- a/test/mock_database_reference_test.dart
+++ b/test/mock_database_reference_test.dart
@@ -7,6 +7,7 @@ void main() {
   late DatabaseReference databaseReference;
   setUp(() {
     setupFirebaseMocks(); // Just to make sure it that no exception is thrown.
+    MockFirebaseDatabase.setDataPersistenceEnabled(enabled: false);
     databaseReference = MockFirebaseDatabase.instance.ref();
   });
 
@@ -373,6 +374,19 @@ void main() {
         }),
       );
     });
+
+    test('should work on root reference', () async {
+      await databaseReference.update({
+        'update': 'foo',
+      });
+      final snapshot = await databaseReference.get();
+      expect(
+        snapshot.value,
+        equals({
+          'update': 'foo',
+        }),
+      );
+    });
   });
 
   group('push', () {
@@ -424,14 +438,34 @@ void main() {
 
     test('should remove shallow data', () async {
       await shallowReference.remove();
-      final snapshot = await shallowReference.get();
-      expect(snapshot.exists, isFalse);
+      final snapshot = await reference.get();
+      expect(
+        snapshot.value,
+        equals({
+          'nested': {
+            'foo': {
+              'bar': 'baz',
+            },
+          },
+        }),
+      );
     });
 
     test('should remove nested data', () async {
       await nestedReference.remove();
-      final snapshot = await nestedReference.get();
-      expect(snapshot.exists, isFalse);
+      final snapshot = await reference.get();
+      expect(
+        snapshot.value,
+        equals({
+          'shallow': 'data',
+        }),
+      );
+    });
+
+    test('should work on root reference', () async {
+      await databaseReference.remove();
+      final snapshot = await databaseReference.get();
+      expect(snapshot.value, isNull);
     });
 
     // todo: uncomment when fixed


### PR DESCRIPTION
**Summary**
- moved ```_volatileData``` from ```MockDatabaseReference``` to ```MockFirebaseDatabase```, as discussed in #9 
- implemented ```update``` and ```remove``` methods for ```MockDatabaseReference```
- added tests for new methods

I did not set 'non-persistent' mode as the default, since I didn't know if you want this change or not, though I used it when testing ```MockDatabaseReference```. Without it one of my newly written tests would fail when all tests in the project were executed together, and that's the thing I talked about in #9.

I hope that you don't mind @sitatec, but I also rewrote the code for ```set``` method. It did not work properly with ```null``` value, often setting it in the wrong place. Since it was too hard for me to understand your code, I decided to simplify it.

I left some todos in the code, there are also some others things to consider, but I will address this in a separate PR, if you decide to merge this one in its current form.