### PR TITLE
Add keepSync override to DatabaseReference

### DIFF
--- a/lib/src/mock_database_reference.dart
+++ b/lib/src/mock_database_reference.dart
@@ -213,6 +213,11 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
 
   @override
   Future<void> remove() => set(null);
+
+  @override
+  Future<void> keepSynced(bool value) async {
+    //Do nothing
+  }
 }
 
 // Map<String, dynamic> _makeSupportGenericValue(Map<String, dynamic> data) {


### PR DESCRIPTION
Hello. Thanks for your good library.
I added the [keepSynced](https://firebase.google.com/docs/database/flutter/offline-capabilities#section-prioritizing-the-local-cache) method to the MockDatabaseReference because it was missing. This method is related to the local cache, so it is appropriate to do nothing in the mock.
You can merge it if you like.