### PR TITLE
Upgraded dependencies (firebase_database to 11.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.0
+* Upgraded dependencies (firebase_database to 11.0.4)
+* Removed deprecated `reference()` method for `MockFirebaseDatabase`
 ## 0.6.1
 * Upgrade to flutter and dependencies
 ## 0.6.0

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ class UserRepository {
 
   Future<String> getUserName(String userId) async {
     final userNameReference =
-        firebaseDatabase.reference().child('users').child(userId).child('name');
+        firebaseDatabase.ref().child('users').child(userId).child('name');
     final dataSnapshot = await userNameReference.once();
     return dataSnapshot.value;
   }
 
   Future<Map<String, dynamic>> getUser(String userId) async {
-    final userNode = firebaseDatabase.reference().child('users/$userId');
+    final userNode = firebaseDatabase.ref().child('users/$userId');
     final dataSnapshot = await userNode.once();
     return dataSnapshot.value;
   }
@@ -59,7 +59,7 @@ void main() {
       }
     }
   };
-  MockFirebaseDatabase.instance.reference().set(fakeData);
+  MockFirebaseDatabase.instance.ref().set(fakeData);
   setUp(() {
     firebaseDatabase = MockFirebaseDatabase.instance;
     userRepository = UserRepository(firebaseDatabase);
@@ -93,7 +93,6 @@ for testing a firebase service that isn't fully mocked.
 ### Supported getters/methods
 - ```MockFirebaseDatabase```
     - ```ref()```
-    - ```reference()```
 - ```MockDatabaseReference```
     - ```key```
     - ```path```

--- a/lib/src/mock_firebase_database.dart
+++ b/lib/src/mock_firebase_database.dart
@@ -11,9 +11,6 @@ class MockFirebaseDatabase extends Mock implements FirebaseDatabase {
   Map<String, dynamic> _volatileData = <String, dynamic>{};
 
   @override
-  DatabaseReference reference() => ref();
-
-  @override
   DatabaseReference ref([String? path]) {
     if (path != null) {
       return MockDatabaseReference(_volatileData).child(path);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_database_mocks
 
 description: Fakes to write unit tests for FirebaseDatabase (real-time database).
 
-version: 0.6.1
+version: 0.7.0
 
 repository: https://github.com/sitatec/firebase_database_mocks.git
 homepage: https://github.com/sitatec/firebase_database_mocks.git
@@ -16,9 +16,9 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  firebase_database: ^10.3.4
-  mockito: ^5.4.2
-  firebase_core_platform_interface: ^5.0.0
+  firebase_database: ^11.0.4
+  mockito: ^5.4.4
+  firebase_core_platform_interface: ^5.2.0
 
 dev_dependencies:
   flutter_lints: ^3.0.1

--- a/test/mock_database_reference_test.dart
+++ b/test/mock_database_reference_test.dart
@@ -18,12 +18,6 @@ void main() {
         MockDatabaseReference().child("initialPath").path,
       );
     });
-    test("Should get reference using the deprecated reference() method", () {
-      expect(
-        MockFirebaseDatabase.instance.reference().child("deprecated").path,
-        MockDatabaseReference().child("deprecated").path,
-      );
-    });
     test('Should work with slash as prefix', () {
       expect(
         databaseReference.child('/test').path,


### PR DESCRIPTION
As firebase upgrades, multiple dependencies need to be upgraded.

firebase_database:
10.3.4 -> 11.0.4
firebase_core_platform_interface:
5.0.0 -> 5.2.0
mockito:
5.4.2 -> 5.4.4

I took the chance to bump the version of the library to 0.7.0 as reference() got deprecated and this might break the code 