### PR TITLE
fix: resolve issue after upgrade firebase_database to ^11.2.0

### DIFF
--- a/lib/src/set_up_mocks.dart
+++ b/lib/src/set_up_mocks.dart
@@ -1,4 +1,4 @@
-import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:firebase_core_platform_interface/test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Set up firebase core for tests.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  firebase_database: ^11.1.0
+  firebase_database: ^11.2.0
   mockito: ^5.4.4
-  firebase_core_platform_interface: ^5.2.1
+  firebase_core_platform_interface: ^5.3.1
 
 dev_dependencies:
-  flutter_lints: ^3.0.1
+  flutter_lints: ^5.0.0


### PR DESCRIPTION
## What it does

- update the library version 
  ```yaml
  dependencies:
    flutter:
      sdk: flutter
    flutter_test:
      sdk: flutter
    firebase_database: ^11.2.0
    mockito: ^5.4.4
    firebase_core_platform_interface: ^5.3.1

  dev_dependencies:
    flutter_lints: ^5.0.0
  ```
- fix the wrong import path for `setupFirebaseCoreMocks` method after upgrade `firebase_database` to ^11.2.0

## How to test

1.  upgrade your `firebase_database` version
2. run the test
3.

## Screenshot
![image](https://github.com/user-attachments/assets/6a58ab46-95ca-4a4f-bc10-0664da78a838)

