### PR TITLE
fix code to avoid flutter analyze errors

### DIFF
--- a/lib/src/mock_data_snapshot.dart
+++ b/lib/src/mock_data_snapshot.dart
@@ -53,7 +53,7 @@ class MockDataSnapshot extends Mock implements DataSnapshot {
     if (value is Map) {
       return value
           .map((key, value) =>
-              MapEntry(key, MockDataSnapshot(_ref.child(key), value)))
+              MapEntry(key, MockDataSnapshot(_ref.child(key as String), value)))
           .values;
     } else if (value is List) {
       var index = 0;

--- a/lib/src/mock_database_reference.dart
+++ b/lib/src/mock_database_reference.dart
@@ -15,7 +15,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
 
   MockDatabaseReference([this._volatileData]);
 
-  MockDatabaseReference._(nodePath, [this._volatileData]) {
+  MockDatabaseReference._(String nodePath, [this._volatileData]) {
     _nodePath += nodePath;
   }
 
@@ -31,11 +31,12 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     return _volatileData;
   }
 
-  set _data(data) {
+  set _data(Map<String, dynamic>? data) {
     if (MockFirebaseDatabase.persistData) {
       _persistedData = data;
-    } else
-      return _volatileData = data;
+    } else {
+      _volatileData = data;
+    }
   }
 
   @override
@@ -70,7 +71,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     value = _parseValue(value);
 
     if (_nodePath == '/') {
-      _data = value;
+      _data = value as Map<String, dynamic>?;
       return;
     }
 
@@ -87,7 +88,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
 
   @override
   Future<void> update(Map<String, Object?> value) async {
-    value = _parseValue(value);
+    value = _parseValue(value) as Map<String, Object?>;
     Map<String, dynamic> _baseData = _getDataHandle(_nodePath, _data, true)!;
 
     if (key != null && _baseData[key] == null) {
@@ -95,7 +96,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
     }
 
     if (key != null) {
-      _baseData = _baseData[key]!;
+      _baseData = _baseData[key]! as Map<String, dynamic>;
     }
 
     for (var _key in value.keys) {
@@ -166,7 +167,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
         _data[segment] = <String, dynamic>{};
       }
 
-      _data = _data[segment];
+      _data = _data[segment] as Map<String, dynamic>?;
     }
 
     return _data;
@@ -188,7 +189,7 @@ class MockDatabaseReference extends Mock implements DatabaseReference {
           break;
         }
         if (tempData[nodePath] is Map) {
-          tempData = tempData[nodePath];
+          tempData = tempData[nodePath] as Map<String, dynamic>?;
         }
       }
     }

--- a/lib/src/mock_firebase_database.dart
+++ b/lib/src/mock_firebase_database.dart
@@ -6,7 +6,7 @@ import 'mock_database_reference.dart';
 class MockFirebaseDatabase extends Mock implements FirebaseDatabase {
   static FirebaseDatabase get instance => MockFirebaseDatabase();
 
-  static get persistData => _persistData;
+  static bool get persistData => _persistData;
 
   Map<String, dynamic> _volatileData = <String, dynamic>{};
 


### PR DESCRIPTION
Some parts in the current code are causing errors in the flutter analyzer, and the errors are also displayed in the IDE.
I fix the code to avoid errors.

↓`flutter analyze` result
<details>
<summary> before </summary>

```
info • To-do comment doesn't follow the Flutter style • lib/firebase_database_mocks.dart:1:1 • flutter_style_todos
   info • To-do comment doesn't follow the Flutter style • lib/firebase_database_mocks.dart:2:1 • flutter_style_todos
   info • Local variables should be final • lib/src/mock_data_snapshot.dart:28:7 • prefer_final_locals
   info • Local variables should be final • lib/src/mock_data_snapshot.dart:42:7 • prefer_final_locals
  error • The argument type 'dynamic' can't be assigned to the parameter type 'String'.  • lib/src/mock_data_snapshot.dart:56:57 • argument_type_not_assignable
warning • The type of nodePath can't be inferred; a type must be explicitly provided • lib/src/mock_database_reference.dart:18:27 • inference_failure_on_untyped_parameter
  error • The argument type 'dynamic' can't be assigned to the parameter type 'String'.  • lib/src/mock_database_reference.dart:19:18 • argument_type_not_assignable
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_database_reference.dart:22:3 • flutter_style_todos
   info • The member 'onValue' overrides an inherited member but isn't annotated with '@override' • lib/src/mock_database_reference.dart:23:29 • annotate_overrides
  error • Conditions must have a static type of 'bool' • lib/src/mock_database_reference.dart:28:9 • non_bool_condition
warning • The type of data can't be inferred; a type must be explicitly provided • lib/src/mock_database_reference.dart:34:13 • inference_failure_on_untyped_parameter
  error • Conditions must have a static type of 'bool' • lib/src/mock_database_reference.dart:35:9 • non_bool_condition
  error • A value of type 'dynamic' can't be assigned to a variable of type 'Map<String, dynamic>?' • lib/src/mock_database_reference.dart:36:24 • invalid_assignment
   info • Assignment to a variable of type 'void' • lib/src/mock_database_reference.dart:38:7 • void_checks
   info • Statements in an if should be enclosed in a block • lib/src/mock_database_reference.dart:38:7 • curly_braces_in_flow_control_structures
  error • A value of type 'dynamic' can't be assigned to a variable of type 'Map<String, dynamic>?' • lib/src/mock_database_reference.dart:38:30 • invalid_assignment
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_database_reference.dart:78:5 • flutter_style_todos
  error • A value of type 'dynamic' can't be assigned to a variable of type 'Map<String, Object?>' • lib/src/mock_database_reference.dart:90:13 • invalid_assignment
   info • The local variable '_baseData' starts with an underscore • lib/src/mock_database_reference.dart:91:26 • no_leading_underscores_for_local_identifiers
  error • A value of type 'dynamic' can't be assigned to a variable of type 'Map<String, dynamic>' • lib/src/mock_database_reference.dart:98:19 • invalid_assignment
   info • The local variable '_key' starts with an underscore • lib/src/mock_database_reference.dart:101:14 • no_leading_underscores_for_local_identifiers
   info • The variable '_key' should be final • lib/src/mock_database_reference.dart:101:14 • prefer_final_in_for_each
   info • The local variable '_data' starts with an underscore • lib/src/mock_database_reference.dart:104:13 • no_leading_underscores_for_local_identifiers
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_database_reference.dart:114:7 • flutter_style_todos
   info • The local variable '_data' starts with an underscore • lib/src/mock_database_reference.dart:155:27 • no_leading_underscores_for_local_identifiers
   info • The variable 'segment' should be final • lib/src/mock_database_reference.dart:156:14 • prefer_final_in_for_each
  error • A value of type 'dynamic' can't be assigned to a variable of type 'Map<String, dynamic>?' • lib/src/mock_database_reference.dart:169:15 • invalid_assignment
   info • Local variables should be final • lib/src/mock_database_reference.dart:182:5 • prefer_final_locals
   info • Local variables should be final • lib/src/mock_database_reference.dart:186:9 • prefer_final_locals
  error • A value of type 'dynamic' can't be assigned to a variable of type 'Map<String, dynamic>?' • lib/src/mock_database_reference.dart:191:22 • invalid_assignment
   info • Local variables should be final • lib/src/mock_database_reference.dart:204:5 • prefer_final_locals
   info • Local variables should be final • lib/src/mock_database_reference.dart:210:5 • prefer_final_locals
warning • The return type of 'persistData' cannot be inferred • lib/src/mock_firebase_database.dart:9:14 • inference_failure_on_function_return_type
   info • The private field _volatileData could be 'final' • lib/src/mock_firebase_database.dart:11:24 • prefer_final_fields
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_firebase_database.dart:24:3 • flutter_style_todos
   info • The method is used to change a property • lib/src/mock_firebase_database.dart:25:15 • use_setters_to_change_properties
   info • The local variable '_lastPushTime' starts with an underscore • lib/src/util.dart:13:7 • no_leading_underscores_for_local_identifiers
   info • The local variable '_lastRandChars' starts with an underscore • lib/src/util.dart:16:9 • no_leading_underscores_for_local_identifiers
   info • The local variable '_random' starts with an underscore • lib/src/util.dart:17:9 • no_leading_underscores_for_local_identifiers
   info • Local variables should be final • test/mock_data_snapshot_test.dart:41:7 • prefer_final_locals
   info • Local variables should be final • test/mock_data_snapshot_test.dart:57:7 • prefer_final_locals
   info • Unnecessary use of parentheses • test/mock_data_snapshot_test.dart:65:26 • unnecessary_parenthesis
   info • Unnecessary use of parentheses • test/mock_data_snapshot_test.dart:70:22 • unnecessary_parenthesis
warning • The type argument(s) of 'List' can't be inferred • test/mock_data_snapshot_test.dart:72:37 • inference_failure_on_collection_literal
   info • To-do comment doesn't follow the Flutter style • test/mock_database_reference_test.dart:113:7 • flutter_style_todos
   info • The value of the argument is redundant because it matches the default value • test/mock_database_reference_test.dart:212:63 • avoid_redundant_argument_values
   info • The value of the argument is redundant because it matches the default value • test/mock_database_reference_test.dart:216:63 • avoid_redundant_argument_values
   info • The local variable '_databaseReference' starts with an underscore • test/mock_database_reference_test.dart:217:30 • no_leading_underscores_for_local_identifiers
   info • Local variables should be final • test/mock_database_reference_test.dart:224:7 • prefer_final_locals
   info • Don't invoke 'print' in production code • test/mock_database_reference_test.dart:229:7 • avoid_print
   info • To-do comment doesn't follow the Flutter style • test/mock_database_reference_test.dart:465:5 • flutter_style_todos
   info • To-do comment doesn't follow the Flutter style • test/mock_database_reference_test.dart:474:3 • flutter_style_todos
```
</details>

<details>
<summary> after </summary>

```
  info • To-do comment doesn't follow the Flutter style • lib/firebase_database_mocks.dart:1:1 • flutter_style_todos
   info • To-do comment doesn't follow the Flutter style • lib/firebase_database_mocks.dart:2:1 • flutter_style_todos
   info • Local variables should be final • lib/src/mock_data_snapshot.dart:28:7 • prefer_final_locals
   info • Local variables should be final • lib/src/mock_data_snapshot.dart:42:7 • prefer_final_locals
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_database_reference.dart:22:3 • flutter_style_todos
   info • The member 'onValue' overrides an inherited member but isn't annotated with '@override' • lib/src/mock_database_reference.dart:23:29 • annotate_overrides
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_database_reference.dart:79:5 • flutter_style_todos
   info • The local variable '_baseData' starts with an underscore • lib/src/mock_database_reference.dart:92:26 • no_leading_underscores_for_local_identifiers
   info • The local variable '_key' starts with an underscore • lib/src/mock_database_reference.dart:102:14 • no_leading_underscores_for_local_identifiers
   info • The variable '_key' should be final • lib/src/mock_database_reference.dart:102:14 • prefer_final_in_for_each
   info • The local variable '_data' starts with an underscore • lib/src/mock_database_reference.dart:105:13 • no_leading_underscores_for_local_identifiers
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_database_reference.dart:115:7 • flutter_style_todos
   info • The local variable '_data' starts with an underscore • lib/src/mock_database_reference.dart:156:27 • no_leading_underscores_for_local_identifiers
   info • The variable 'segment' should be final • lib/src/mock_database_reference.dart:157:14 • prefer_final_in_for_each
   info • Local variables should be final • lib/src/mock_database_reference.dart:183:5 • prefer_final_locals
   info • Local variables should be final • lib/src/mock_database_reference.dart:187:9 • prefer_final_locals
   info • Local variables should be final • lib/src/mock_database_reference.dart:205:5 • prefer_final_locals
   info • Local variables should be final • lib/src/mock_database_reference.dart:211:5 • prefer_final_locals
   info • The private field _volatileData could be 'final' • lib/src/mock_firebase_database.dart:11:24 • prefer_final_fields
   info • To-do comment doesn't follow the Flutter style • lib/src/mock_firebase_database.dart:24:3 • flutter_style_todos
   info • The method is used to change a property • lib/src/mock_firebase_database.dart:25:15 • use_setters_to_change_properties
   info • The local variable '_lastPushTime' starts with an underscore • lib/src/util.dart:13:7 • no_leading_underscores_for_local_identifiers
   info • The local variable '_lastRandChars' starts with an underscore • lib/src/util.dart:16:9 • no_leading_underscores_for_local_identifiers
   info • The local variable '_random' starts with an underscore • lib/src/util.dart:17:9 • no_leading_underscores_for_local_identifiers
   info • Local variables should be final • test/mock_data_snapshot_test.dart:41:7 • prefer_final_locals
   info • Local variables should be final • test/mock_data_snapshot_test.dart:57:7 • prefer_final_locals
   info • Unnecessary use of parentheses • test/mock_data_snapshot_test.dart:65:26 • unnecessary_parenthesis
   info • Unnecessary use of parentheses • test/mock_data_snapshot_test.dart:70:22 • unnecessary_parenthesis
warning • The type argument(s) of 'List' can't be inferred • test/mock_data_snapshot_test.dart:72:37 • inference_failure_on_collection_literal
   info • To-do comment doesn't follow the Flutter style • test/mock_database_reference_test.dart:113:7 • flutter_style_todos
   info • The value of the argument is redundant because it matches the default value • test/mock_database_reference_test.dart:212:63 • avoid_redundant_argument_values
   info • The value of the argument is redundant because it matches the default value • test/mock_database_reference_test.dart:216:63 • avoid_redundant_argument_values
   info • The local variable '_databaseReference' starts with an underscore • test/mock_database_reference_test.dart:217:30 • no_leading_underscores_for_local_identifiers
   info • Local variables should be final • test/mock_database_reference_test.dart:224:7 • prefer_final_locals
   info • Don't invoke 'print' in production code • test/mock_database_reference_test.dart:229:7 • avoid_print
   info • To-do comment doesn't follow the Flutter style • test/mock_database_reference_test.dart:465:5 • flutter_style_todos
   info • To-do comment doesn't follow the Flutter style • test/mock_database_reference_test.dart:474:3 • flutter_style_todos
```

</details>