### PR TITLE
fix: bump firebase_database and mockito dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  firebase_database: ^11.3.9
-  mockito: ^5.4.6
+  firebase_database: ^12.0.0
+  mockito: ^5.5.0
   firebase_core_platform_interface: ^6.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Fix this issues:


`Because firebase_database 11.3.10 depends on firebase_core ^3.15.2 and no versions of firebase_database match >11.3.10 <12.0.0, firebase_database ^11.3.10 requires firebase_core ^3.15.2.`

We need to update the library version